### PR TITLE
PiGpio page update to clearly say Pi5 not supported, and it requires …

### DIFF
--- a/content/documentation/providers/_index.md
+++ b/content/documentation/providers/_index.md
@@ -42,7 +42,8 @@ Current supported providers:
     * 03/22/2024 Does not support Raspberry Pi 5
 
 Possible future providers:
-
+* Pi5 SPI, under construction. 
+* Pi5 Serial. At present the intent is no Pi4j Serial provider on Pi5. As an alternative see [jSerialComm](http://fazecast.github.io/jSerialComm/).
 * RemoteProvider to control the I/O from a remote device e.g. through websockets
 
 Pi4J 2.5 Provider not found

--- a/content/documentation/providers/pigpio.md
+++ b/content/documentation/providers/pigpio.md
@@ -4,7 +4,14 @@ weight: 95
 tags: ["PiGpio", "PWM", "I2C", "SPI", "Serial", "Digital Input", "Digital Output"]
 ---
 
-The current implementation of the PiGpio exposes the GPIO functions available on the Raspberry Pi.
+The current implementation of the PiGpio exposes the GPIO functions available on the Raspberry Pi (see Note Pi5 below). 
+This implementation is developed/supported by a team separate of Pi4j.  Pi4j is a consumer of that PiGpio work.
+
+```shell
+Pi5  At the present time the PiGpio implementation does not support the new Pi5 board. 
+- This new Pi5 RP1 chip will require a large development effort. There is no known plan for this develoment.   
+```
+
 
 Providers in the PiGpio plugin:
 


### PR DESCRIPTION
…effort from group outside of Pi4j.  Also clarify Pi5 SPI support under construction and Serial will not be in Pi4j but identifies substitute


@eitch @FDelporte   Forum post fellow didn't read the provider details from top down so he missed the detail pigpio doesn't work on Pi5.  So I added some details to the pigpio page itself.   Also clarified SPI and Serial on Pi5 as I assume those questions are coming.

Frank, please suggest any different way I should make these changes.  Not certain on which form of ``` ``` should be used.