### PR TITLE
Update Minimal Example Application Documentation after bump dependency

### DIFF
--- a/content/getting-started/minimal-example-application.md
+++ b/content/getting-started/minimal-example-application.md
@@ -28,9 +28,9 @@ so you can select the tool you prefer.
 
 ### Maven
 
-This project can be built with Apache Maven 3.6 (or later) and Java 11 OpenJDK (or later). These prerequisites must be 
+This project can be built with Apache Maven 3.6 (or later) and Java 17 OpenJDK (or later). These prerequisites must be 
 installed prior to building this project as described on the previous pages. The following command can be used to 
-download all project dependencies and compile the Java module. You can build this project directly on a Raspberry Pi with Java 11+.
+download all project dependencies and compile the Java module. You can build this project directly on a Raspberry Pi with Java 17+.
 
 ```
 mvn clean package
@@ -38,7 +38,7 @@ mvn clean package
 
 ### Gradle
 
-You can also use the Gradle Build Tool from these same sources. Use version 6.6 (or later) and Java 11 OpenJDK (or later). 
+You can also use the Gradle Build Tool from these same sources. Use version 6.6 (or later) and Java 17 OpenJDK (or later). 
 The Gradle wrapper is used as described on [docs.gradle.org](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 The Gradle configuration file [build.gradle-file](https://github.com/Pi4J/pi4j-example-minimal/blob/master/build.gradle) 
 is included in the sources.
@@ -65,8 +65,8 @@ make the versions easy to update, we add those numbers as properties.
 ```xml
 <properties>
     <!-- DEPENDENCIES VERSIONS -->
-    <slf4j.version>2.0.12</slf4j.version>
-    <pi4j.version>2.5.1</pi4j.version>
+    <slf4j.version>2.0.16</slf4j.version>
+    <pi4j.version>2.7.0</pi4j.version>
 </properties>
 ``` 
   
@@ -193,13 +193,13 @@ pi4j.shutdown();
 ## Steps to run this application on your Raspberry Pi
 
 * Attach a LED and button as shown in the image above
-* Use a recent Raspbian OS image which has Java 11 or newer. To check if you have the correct Java version in the terminal:
+* Use a recent Raspbian OS image which has Java 17 or newer. To check if you have the correct Java version in the terminal:
 
 ```shell
 $ java -version
-openjdk version "11.0.6" 2020-01-14
-OpenJDK Runtime Environment (build 11.0.6+10-post-Raspbian-1deb10u1)
-OpenJDK Server VM (build 11.0.6+10-post-Raspbian-1deb10u1, mixed mode)
+openjdk version "17.0.7" 2023-04-18
+OpenJDK Runtime Environment (build 17.0.7+7-Debian-1deb11u1)
+OpenJDK 64-Bit Server VM (build 17.0.7+7-Debian-1deb11u1, mixed mode, sharing)
 ``` 
 
 * Download the project from GitHub and build it:
@@ -215,15 +215,15 @@ $ mvn clean package
 ```shell
 $ cd target/distribution
 $ ls -l
-total 608
--rw-r--r-- 1 pi pi 310147 Mar 21 09:53 pi4j-core-2.5.1.jar
--rw-r--r-- 1 pi pi   6240 Mar 21 10:48 pi4j-example-minimal-0.0.1.jar
--rw-r--r-- 1 pi pi 158381 Mar 21 09:52 pi4j-library-gpiod-2.5.1.jar
--rw-r--r-- 1 pi pi  22202 Mar 21 09:52 pi4j-plugin-gpiod-2.5.1.jar
--rw-r--r-- 1 pi pi  26919 Mar 21 09:52 pi4j-plugin-raspberrypi-2.5.1.jar
--rwxr-xr-x 1 pi pi    101 Mar 21 10:48 run.sh
--rw-r--r-- 1 pi pi  68115 Feb  5 22:32 slf4j-api-2.0.12.jar
--rw-r--r-- 1 pi pi  15701 Feb  5 22:33 slf4j-simple-2.0.12.jar
+total 644
+-rw-r--r-- 1 pi pi 344544 Oct 21 08:07 pi4j-core-2.7.0.jar
+-rw-r--r-- 1 pi pi   7134 Oct 21 08:08 pi4j-example-minimal-0.0.1.jar
+-rw-r--r-- 1 pi pi 158997 Oct 21 08:07 pi4j-library-gpiod-2.7.0.jar
+-rw-r--r-- 1 pi pi  22633 Oct 21 08:07 pi4j-plugin-gpiod-2.7.0.jar
+-rw-r--r-- 1 pi pi  28051 Oct 21 08:07 pi4j-plugin-raspberrypi-2.7.0.jar
+-rwxr-xr-x 1 pi pi    101 Oct 21 08:08 run.sh
+-rw-r--r-- 1 pi pi  69435 Oct 21 08:07 slf4j-api-2.0.16.jar
+-rw-r--r-- 1 pi pi  15704 Oct 21 08:07 slf4j-simple-2.0.16.jar
 ```
 
 * Start the application with the provided `run.sh` script:


### PR DESCRIPTION
This PR updates the **Minimal Example Application** documentation to reflect changes in dependency versions and Java requirements after the [recent dependency upgrades](https://github.com/Pi4J/pi4j-example-minimal/pull/9).

**Key Changes:**

- Updated the required Java version from 11 to 17 throughout the document.
- Bumped SLF4J from version 2.0.12 to 2.0.16.
- Bumped Pi4J from version 2.5.1 to 2.7.0.
- Updated example output and file listings to reflect new artifact versions and sizes. 

**Context**:

These updates ensure that the documentation is consistent with the latest versions of dependencies and Java requirements, improving clarity for users building the minimal example on modern setups.