### PR TITLE
WIP: Update Debugging Failures Documentation: Fix for CPU Detection Error in Pi4J 2.7.0

### DIFF
--- a/content/debugging-failures/_index.md
+++ b/content/debugging-failures/_index.md
@@ -67,6 +67,23 @@ Caused by: java.lang.reflect.InvocationTargetException
 Caused by: com.pi4j.library.pigpio.PiGpioException: PIGPIO ERROR: PI_INIT_FAILED; pigpio initialisation failed
 ```
 
+### Error: `Could not execute cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' to detect the board model`
+
+This error occurs in Pi4J **version 2.7.0**, due to a problem where a shell command is used to detect the board model, but fails with a permission error (`IOException: Cannot run program "sh": error=13, Permission denied`).
+
+**Solutions:**
+1. **Upgrade to Pi4J Version 2.7.1 or Newer:**
+In version 2.7.1, this issue has been resolved. The `/proc/cpuinfo` file is read directly in Java without using shell commands, avoiding the permission issue entirely.
+
+2. **Grant Execution Permission to** `jspawnhelper`:
+If upgrading is not immediately possible, you can manually fix the issue by ensuring the `jspawnhelper` utility in the Java runtime has execution permissions. Run the following command:
+
+```shell
+chmod +x JAVA_HOME/lib/jspawnhelper
+```
+
+Replace `JAVA_HOME` with the actual path to your Java installation. This ensures that Java can execute shell commands without permission errors.
+
 ## Unexpected Results on Electronic Components
 
 If your software starts OK, and the log output shows that everything works as expected, but you still don't get the desired result on the connected electronic component, check:


### PR DESCRIPTION
As described in [Issue #421](https://github.com/Pi4J/pi4j-v2/issues/421) and based on the solution provided by @byRizon, I've updated the **Debugging Failures Documentation** page to address the following issue:

`Could not execute cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' to detect the board model: IOException: Cannot run program "sh": error=13, Permission denied`

**Status:**

The PR is currently a Work in Progress (WIP), awaiting clarification from [Issue #421](https://github.com/Pi4J/pi4j-v2/issues/421#issuecomment-2507126580) to determine the best course of action:

- Should we wait for the 2.7.1 release and merge the PR with the upgrade recommendation?
- Or merge the PR now with the permission workaround included, and update it later after the new release?