### PR TITLE
Fix typos and invalid Link

### DIFF
--- a/content/architecture/about-the-code/build-instructions.md
+++ b/content/architecture/about-the-code/build-instructions.md
@@ -5,14 +5,14 @@ weight: 30
 
 Building the Pi4J Project is simple and requires minimal effort.  Pi4J is primarily built using Apache Maven and Java 11. 
 Pi4J can be built directly on your host computer or inside a Docker container where all toolchains and dependencies are 
-already installed, configuired and cached.   
+already installed, configured and cached.   
 
 {{% notice note %}}If you wish to build using a Docker container, please skip ahead to the 
 [_Building with Docker_](#building-with-docker) topic.{{% /notice %}}
 
 ---
 
-### Prerequsites
+### Prerequisites
 
 In order to build  Pi4J, the host system must have the following toolchains pre-installed.
 

--- a/content/documentation/building/_index.md
+++ b/content/documentation/building/_index.md
@@ -4,7 +4,7 @@ weight: 160
 ---
 
 When you create your application with and IDE on the Raspberry Pi itself (e.g. with Visual Studio Code), you can simply
-run the application. But ofcourse, you want to build and package your project to easily deploy it on one or more Raspberry
+run the application. But of course, you want to build and package your project to easily deploy it on one or more Raspberry
 Pi's.
 
 There are different possibilities:

--- a/content/documentation/providers/_index.md
+++ b/content/documentation/providers/_index.md
@@ -14,7 +14,7 @@ inputs at the same time.
 
 As of Pi4J 2.5 multiple providers for the same I/O type is no longer supported. During the Context initialization it will
 ensure only a single provider for an I/O type is loaded. In addition the Mock Providers are not loaded unless 
-expressly requested when creating the Context.  [See Create Context](../create-context.md)
+expressly requested when creating the Context.  [See Create Context](../create-context/)
 
 Current supported providers:
 

--- a/content/examples/communityImplementation/bmp280.md
+++ b/content/examples/communityImplementation/bmp280.md
@@ -14,7 +14,7 @@ access the device with existing software requiring no coding.  The document will
 also explain minimal coding required to allow greater flexibility.
 
 A later section explains creating a more robust proto-type environment to better
-support using variuos integrated circuits, see [Prototype board](/examples/communityimplementation/prototype-board/).
+support using various integrated circuits, see [Prototype board](/examples/communityimplementation/prototype-board/).
 
 ### Connecting Adafruit BMP280
 

--- a/static/0.0.5/apidocs/com/pi4j/io/gpio/exception/package-summary.html
+++ b/static/0.0.5/apidocs/com/pi4j/io/gpio/exception/package-summary.html
@@ -122,7 +122,7 @@
 <tr class="altColor">
 <td class="colFirst"><a href="../../../../../com/pi4j/io/gpio/exception/UnsupportedPinPullResistanceException.html" title="class in com.pi4j.io.gpio.exception">UnsupportedPinPullResistanceException</a></td>
 <td class="colLast">
-<div class="block">Unsupported pin pull up/down resistence exception.</div>
+<div class="block">Unsupported pin pull up/down resistance exception.</div>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
This PR addresses minor corrections in the documentation, including:

- Fixing typographical errors (e.g., "variuos" → "various," "resistence" → "resistance").
- Correcting an invalid link in the Create Context section.