### PR TITLE
Update Documentation for BoardInfoHelper to Include Throttled States Methods

### DIFF
--- a/content/documentation/board-info.md
+++ b/content/documentation/board-info.md
@@ -61,16 +61,25 @@ var pi4j = Pi4J.newAutoContext();
 // performed. You can use this info in case you need board-specific
 // functionality.
 // OPTIONAL
+
+// Display board information
 console.println("Board model: " + pi4j.boardInfo().getBoardModel().getLabel());
 console.println("Operating system: " + pi4j.boardInfo().getOperatingSystem());
 console.println("Java versions: " + pi4j.boardInfo().getJavaInfo());
-// This info is also available directly from the BoardInfoHelper, 
-// and with some additional realtime data.
+
+// Access additional info via BoardInfoHelper
 console.println("Board model: " + BoardInfoHelper.current().getBoardModel().getLabel());
 console.println("Raspberry Pi model with RP1 chip (Raspberry Pi 5): " + BoardInfoHelper.usesRP1());
 console.println("OS is 64-bit: " + BoardInfoHelper.is64bit());
 console.println("JVM memory used (MB): " + BoardInfoHelper.getJvmMemory().getUsedInMb());
 console.println("Board temperature (°C): " + BoardInfoHelper.getBoardReading().getTemperatureInCelsius());
+
+// Access throttled states
+var throttledStates = BoardInfoHelper.getBoardReading().getThrottledStates();
+console.println("Throttled states: ");
+throttledStates.forEach(state -> console.println(" - " + state.name()));
+
+console.println("Throttled states description: " + BoardInfoHelper.getBoardReading().getThrottledStatesDescription());
 ```
 
 ### Example Output
@@ -80,10 +89,14 @@ console.println("Board temperature (°C): " + BoardInfoHelper.getBoardReading().
 [main] INFO com.pi4j.util.Console - Operating system: Name: Linux, version: 6.1.21-v8+, architecture: aarch64
 [main] INFO com.pi4j.util.Console - Java versions: Version: 22, runtime: 22+36, vendor: Azul Systems, Inc., vendor version: Zulu22.28+91-CA
 
-
 [main] INFO com.pi4j.util.Console - Board model: Raspberry Pi 4 Model B
 [main] INFO com.pi4j.util.Console - Raspberry Pi model with RP1 chip (Raspberry Pi 5): false
 [main] INFO com.pi4j.util.Console - OS is 64-bit: true
 [main] INFO com.pi4j.util.Console - JVM memory used (MB): 10.910163879394531
 [main] INFO com.pi4j.util.Console - Board temperature (°C): 61.3
+
+[main] INFO com.pi4j.util.Console - Throttled states: 
+[main] INFO com.pi4j.util.Console -  - UNDERVOLTAGE_DETECTED
+[main] INFO com.pi4j.util.Console -  - SOFT_TEMPERATURE_LIMIT_ACTIVE
+[main] INFO com.pi4j.util.Console - Throttled states description: Under-voltage detected, Soft temperature limit active
 ```

--- a/content/documentation/board-info.md
+++ b/content/documentation/board-info.md
@@ -19,11 +19,16 @@ The board info is used in some of the plugins to set the correct priority, based
 
 ## How the Board Model is Detected
 
-The model is detected based on the board version number that is written inside the board and can be read with:
+### Previous Method (< 2.7.1 version)
+In earlier versions, the board model was determined by reading the board version number from the `/proc/cpuinfo` file using shell commands:
 
 ```shell
 $ cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}'
 ```
+
+### Updated Method (>= 2.7.1 version)
+Starting with version 2.7.1, the board version number is determined programmatically in Java using the [CpuInfoReader](https://github.com/Pi4J/pi4j-v2/blob/develop/pi4j-core/src/main/java/com/pi4j/boardinfo/datareader/CpuInfoReader.java) class. This method reads and processes the `/proc/cpuinfo` file to extract the CPU revision.
+
 
 For instance, for a Raspberry Pi Compute 4, multiple version numbers are possible:
 


### PR DESCRIPTION
This update enhances the documentation for the `BoardInfoHelper` class to reflect the new methods for retrieving throttled states.

Related to https://github.com/Pi4J/pi4j-v2/pull/432