### PR TITLE
add SPI capability to linuxfs provider description.  in io-example PW…

### DIFF
--- a/content/documentation/io-examples/pwm.md
+++ b/content/documentation/io-examples/pwm.md
@@ -79,6 +79,7 @@ As of version 2.6.0 of Pi4J, `linuxfs-pwm` also supports hardware PMW on the Ras
 Only hardware PWM is supported.
 
 ### PWM GPIOs
+The channel number in the following charts are supplied as the buildPwmConfig config value ```address```.
 
 The user must modify `config.txt` to enable PWM. 
 

--- a/content/documentation/providers/_index.md
+++ b/content/documentation/providers/_index.md
@@ -28,7 +28,7 @@ Current supported providers:
   * Pro
     * Works on Raspberry Pi 5
     * Generic for any SoC supporting LinuxFS
-    * Supports I2C, and PWM Hardware
+    * Supports I2C, SPI, and PWM Hardware
     * Doesn't need `sudo`
   * Contra
     * Doesn't provide serial and SPI 

--- a/content/documentation/providers/linuxfs.md
+++ b/content/documentation/providers/linuxfs.md
@@ -70,6 +70,20 @@ The buffer size for this SPI implementation is 4096 bytes. This can be configure
 * Debian Bullseye OS: `/boot/config.txt`
 * Raspberry Pi OS, based on Debian Bookworm: `/boot/firmware/config.txt`
 
+```java
+      var spiConfig = Spi.newConfigBuilder(pi4j)
+        .id(SPI_PROVIDER_ID)
+        .name(SPI_PROVIDER_NAME)
+        .bus(spiBus)
+        .chipSelect(chipSelect)
+        .baud(Spi.DEFAULT_BAUD)
+        .mode(SpiMode.MODE_0)
+        .provider("linuxfs-spi")
+        .build();
+var spi = pi4j.create(spiConfig);
+
+```
+
 ## PWM
 
 Example on how to use PWM with LinuxFS:


### PR DESCRIPTION
…M, make sure the gpio vs channel usages are clear ad pipgpio and linuxfs do things differently