### PR TITLE
Add Sense HAT video to Videos section

### DIFF
--- a/content/video/20260701-sense-hat-pi4j-drivers.md
+++ b/content/video/20260701-sense-hat-pi4j-drivers.md
@@ -1,0 +1,23 @@
+---
+title: '2026 Sense HAT with Pi4J'
+date: 2026-07-01
+youtube: w7xxDu7lJPE
+tags: ["Video", "Drivers"]
+---
+
+## Using the Raspberry Pi Sense HAT with Pi4J Drivers
+
+**20260701 - Video with Igor De Souza**
+
+{{< youtube w7xxDu7lJPE >}}
+
+The [Sense HAT](https://www.raspberrypi.com/products/sense-hat/) packs an 8×8 RGB LED matrix, environmental sensors (temperature, humidity, and pressure), motion sensors (accelerometer, gyroscope, and magnetometer), and a small joystick onto a single Raspberry Pi expansion board. In this video, Igor De Souza shows how Java developers can talk to all of that hardware through [Pi4J Drivers](/drivers/), the companion library to [Pi4J](https://www.pi4j.com/).
+
+Instead of implementing the I2C communication for each sensor by hand, Pi4J Drivers wraps the Sense HAT in a clean, consistent Java API: create a `SenseHat` instance and start reading the sensors and driving the LED matrix with straightforward method calls, without manual register handling.
+
+* [Pi4J website](https://www.pi4j.com/)
+* [Pi4J Drivers](/drivers/)
+* [Blog post: Sense HAT with Pi4J](/blog/2026/20260701-sense-hat-pi4j-drivers/)
+* [Foojay article: Using the Raspberry Pi Sense HAT with Pi4J Drivers](https://foojay.io/today/using-the-raspberry-pi-sense-hat-with-pi4j-drivers/)
+* [Pi4J Examples](https://github.com/Pi4J/pi4j-example-drivers)
+* [Pi4J GitHub Discussions](https://github.com/Pi4J/pi4j/discussions)


### PR DESCRIPTION
## Summary
Adds a `/video` listing entry for the **Sense HAT with Pi4J** screencast (YouTube `w7xxDu7lJPE`).

The July 1 blog post [_Sense HAT with Pi4J_](/blog/2026/20260701-sense-hat-pi4j-drivers/) embeds the video inline, but the Videos page — the canonical list of Pi4J screencasts — didn't include it yet. Since the Videos page is a separate discoverability surface, the video was invisible to anyone browsing that section.

New file `content/video/20260701-sense-hat-pi4j-drivers.md` mirrors the existing pattern (e.g. `20260625-smoketest-pcb.md`): front matter with `title`/`date`/`youtube`/`tags`, the `{{< youtube >}}` shortcode, a short description, and reference links.

## Test plan
- `hugo` builds without errors and the entry appears on the Videos listing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)